### PR TITLE
initial version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Sourced Technologies, S.L.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # go-cli
 
+**This is currently experimental. API, package name and import path might change any time.**
 
+A thin wrapper around common libraries used in our CLI apps (`jessevdk/go-flags`, `src-d/go-log`, `pprof`) to reduce boilerplate code and help in being more homogeneous with respect how our CLI work and look like.
+
+It provides:
+- Struct tags to specify command names and descriptions (see below).
+- Default version subcommand.
+- Flags and environment variables to setup logging with src-d/go-log.
+- Flags and environment variables to setup a http/pprof endpoint.
+- Signal handling.
+
+For further details, look at `doc.go`.
+
+## License
+
+Apache License Version 2.0, see LICENSE(LICENSE).

--- a/addcommand.go
+++ b/addcommand.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+)
+
+// AddCommand adds a new command to the application. The command must have a
+// special field defining name, short-description and long-description (see
+// package documentation). It panics if the command is not valid.
+// Returned CommandAdder can be used to add subcommands.
+//
+// Additional functions can be passed to manipulate the resulting *flags.Command
+// after its initialization.
+func (a *App) AddCommand(cmd interface{}, cfs ...func(*flags.Command)) CommandAdder {
+	return commandAdder{a.Parser}.AddCommand(cmd, cfs...)
+}
+
+// CommandAdder can be used to add subcommands.
+type CommandAdder interface {
+	// AddCommand adds the given commands as subcommands of the
+	// cuurent one.
+	AddCommand(interface{}, ...func(*flags.Command)) CommandAdder
+}
+
+type commandAdder struct {
+	internalCommandAdder
+}
+
+type internalCommandAdder interface {
+	AddCommand(string, string, string, interface{}) (*flags.Command, error)
+}
+
+func (a commandAdder) AddCommand(cmd interface{}, cfs ...func(*flags.Command)) CommandAdder {
+	typ, err := getStructType(cmd)
+	if err != nil {
+		panic(err)
+	}
+
+	under, ok := typ.FieldByName("_")
+	if !ok {
+		panic(fmt.Errorf("missing `_` field"))
+	}
+
+	name := under.Tag.Get("name")
+	shortDescription := under.Tag.Get("short-description")
+	longDescription := under.Tag.Get("long-description")
+
+	if v, ok := cmd.(ContextCommander); ok {
+		cmd = &nopCommander{v}
+	}
+
+	c, err := a.internalCommandAdder.AddCommand(
+		name, shortDescription, longDescription, cmd)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, cf := range cfs {
+		cf(c)
+	}
+
+	return commandAdder{c}
+}

--- a/cli.go
+++ b/cli.go
@@ -101,10 +101,15 @@ type initializer interface {
 	init(*App) error
 }
 
+// PlainCommand should be embedded in a struct to indicate that it implements a
+// command. See package documentation for its usage.
+type PlainCommand struct{}
+
 // Command implements the default group flags. It is meant to be embedded into
 // other application commands to provide default behavior for logging,
 // profiling, etc.
 type Command struct {
+	PlainCommand
 	LogOptions      `group:"Log Options"`
 	ProfilerOptions `group:"Profiler Options"`
 }

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+
+	"github.com/jessevdk/go-flags"
+)
+
+// App defines the CLI application that will be run.
+type App struct {
+	Parser *flags.Parser
+
+	// DebugServeMux is serves debug endpoints. It used to attach the http/pprof
+	// endpoint if enabled, and can be used to handle other debug endpoints.
+	DebugServeMux *http.ServeMux
+}
+
+// New creates a new App, including default values.
+func New(name, version, build, description string) *App {
+	parser := flags.NewNamedParser(name, flags.Default)
+	parser.LongDescription = description
+	app := &App{
+		Parser:        parser,
+		DebugServeMux: http.NewServeMux(),
+	}
+
+	app.Parser.CommandHandler = app.commandHandler
+
+	app.AddCommand(&VersionCommand{
+		Name:    name,
+		Version: version,
+		Build:   build,
+	})
+
+	return app
+}
+
+// Run runs the app with the given command line arguments. In order to reduce
+// boilerplate, RunMain should be used instead.
+func (a *App) Run(args []string) error {
+	if _, err := a.Parser.ParseArgs(args[1:]); err != nil {
+		if err, ok := err.(*flags.Error); ok {
+			if err.Type == flags.ErrHelp {
+				return nil
+			}
+
+			a.Parser.WriteHelp(os.Stderr)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// RunMain runs the application with os.Args and if there is any error, it
+// exits with error code 1.
+func (a *App) RunMain() {
+	if err := a.Run(os.Args); err != nil {
+		os.Exit(1)
+	}
+}
+
+func (a *App) commandHandler(cmd flags.Commander, args []string) error {
+	if v, ok := cmd.(initializer); ok {
+		if err := v.init(a); err != nil {
+			return err
+		}
+	}
+
+	if v, ok := cmd.(ContextCommander); ok {
+		ctx, cancel := setupContext()
+		defer cancel()
+		return v.ExecuteContext(ctx, args)
+	}
+
+	return cmd.Execute(args)
+}
+
+func getStructType(data interface{}) (reflect.Type, error) {
+	typ := reflect.TypeOf(data)
+	if typ == nil {
+		return nil, fmt.Errorf("expected struct or struct ptr: got nil")
+	}
+
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct or struct ptr: %s", typ.Kind())
+	}
+
+	return typ, nil
+}
+
+type initializer interface {
+	init(*App) error
+}
+
+// Command implements the default group flags. It is meant to be embedded into
+// other application commands to provide default behavior for logging,
+// profiling, etc.
+type Command struct {
+	LogOptions      `group:"Log Options"`
+	ProfilerOptions `group:"Profiler Options"`
+}
+
+// Init initializes the command.
+func (c Command) init(a *App) error {
+	if err := c.LogOptions.init(a); err != nil {
+		return err
+	}
+
+	if err := c.ProfilerOptions.init(a); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelp(t *testing.T) {
+	require := require.New(t)
+
+	app := New("test", "0.1.0", "abc", "my test bin")
+	require.NotNil(app)
+
+	var (
+		stdout, stderr string
+		err            error
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "--help"})
+		})
+	})
+
+	require.NoError(err)
+	require.Empty(stderr)
+	require.Equal(`Usage:
+  test [OPTIONS] <version>
+
+my test bin
+
+Help Options:
+  -h, --help  Show this help message
+
+Available commands:
+  version  print version
+
+`, stdout)
+}
+
+func TestHelpError(t *testing.T) {
+	require := require.New(t)
+
+	app := New("test", "0.1.0", "abc", "my test bin")
+	require.NotNil(app)
+
+	var (
+		stdout, stderr string
+		err            error
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "--bad-option"})
+		})
+	})
+
+	require.Error(err)
+	require.Empty(stdout)
+	require.Equal(`unknown flag `+"`"+`bad-option'
+Usage:
+  test [OPTIONS] <version>
+
+my test bin
+
+Help Options:
+  -h, --help  Show this help message
+
+Available commands:
+  version  print version
+`, stderr)
+}
+
+func TestAddCommandError(t *testing.T) {
+	require := require.New(t)
+
+	app := New("test", "0.1.0", "abc", "my test bin")
+	require.NotNil(app)
+
+	require.Panics(func() {
+		app.AddCommand(nil)
+	})
+
+	require.Panics(func() {
+		app.AddCommand(badCommander(42))
+	})
+
+	require.Panics(func() {
+		app.AddCommand(struct {
+			Command
+			badCommander
+		}{})
+	})
+}
+
+type badCommander int
+
+func (badCommander) Execute(args []string) error {
+	return nil
+}

--- a/context.go
+++ b/context.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// ContextCommander is a cancellable commander.
+type ContextCommander interface {
+	// ExecuteContext executes the command with a context.
+	ExecuteContext(context.Context, []string) error
+}
+
+type nopCommander struct {
+	ContextCommander
+}
+
+func (c nopCommander) Execute(args []string) error {
+	return nil
+}
+
+func (c nopCommander) init(a *App) error {
+	if v, ok := c.ContextCommander.(initializer); ok {
+		return v.init(a)
+	}
+
+	return nil
+}
+
+func setupContext() (context.Context, context.CancelFunc) {
+	var (
+		sigterm = make(chan os.Signal)
+		sigint  = make(chan os.Signal)
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		select {
+		case <-sigterm:
+			log.Infof("signal SIGTERM received, stopping...")
+			cancel()
+		case <-sigint:
+			log.Infof("signal SIGINT received, stopping...")
+			cancel()
+		case <-ctx.Done():
+		}
+
+		signal.Stop(sigterm)
+		signal.Stop(sigint)
+	}()
+
+	signal.Notify(sigterm, syscall.SIGTERM)
+	signal.Notify(sigint, os.Interrupt)
+
+	return ctx, cancel
+}

--- a/doc.go
+++ b/doc.go
@@ -17,11 +17,24 @@ Commands
 Commands are defined with structs. For the general available struct tags, refer
 to jessevdk/go-flags documentation at https://github.com/jessevdk/go-flags.
 
-Additionally, a special field must be defined with the struct tags
-name, short-description and long-description. For example:
+Additionally, every command struct must embed PlainCommand directly, or
+indirectly through other struct (e.g. Command). The embedded field must be
+defined with the struct tags name, short-description and long-description.
+For example:
 
   type helloCommand struct {
-	  _ string `name:"hello" short-description:"prints Hello World" long-description:"prints Hello World to standard output"`
+    Command `name:"hello" short-description:"prints Hello World" long-description:"prints Hello World to standard output"`
+  }
+
+This will also work if nested:
+
+  type myBaseCommand struct {
+    Command
+    Somethig string
+  }
+
+  type helloCommand struct {
+    myBaseCommand `name:"hello" short-description:"prints Hello World" long-description:"prints Hello World to standard output"`
   }
 
 Each defined command must be added to the application with the AddCommand

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,40 @@
+/*
+Package cli provides scaffolding for CLI applications. It is a convenience
+wrapper for jessevdk/go-flags reducing boilerplate code.
+
+The main entry point is the App type, created with the New function.
+
+It provides:
+
+  - Struct tags to specify command names and descriptions (see below).
+  - Default version subcommand.
+  - Flags and environment variables to setup logging with src-d/go-log.
+  - Flags and environment variables to setup a http/pprof endpoint.
+  - Signal handling.
+
+Commands
+
+Commands are defined with structs. For the general available struct tags, refer
+to jessevdk/go-flags documentation at https://github.com/jessevdk/go-flags.
+
+Additionally, a special field must be defined with the struct tags
+name, short-description and long-description. For example:
+
+  type helloCommand struct {
+	  _ string `name:"hello" short-description:"prints Hello World" long-description:"prints Hello World to standard output"`
+  }
+
+Each defined command must be added to the application with the AddCommand
+function.
+
+Signal Handling
+
+Signal handling is setup for any cancellable command. Cancellable commands
+implement the ContextCommander interface instead of flags.Commander.
+
+Examples
+
+See full examples in the examples subpackage.
+
+*/
+package cli

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+var (
+	version string
+	build   string
+)
+
+var app = cli.New("basic", version, build, "my basic command")
+
+func main() {
+	app.RunMain()
+}

--- a/examples/basic/main_test.go
+++ b/examples/basic/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+	require := require.New(t)
+	os.Args = []string{"test", "--help"}
+	var (
+		stdout, stderr string
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			main()
+		})
+	})
+
+	require.Empty(stderr)
+	require.True(strings.HasPrefix(stdout, "Usage:\n  basic"))
+}

--- a/examples/basic/print.go
+++ b/examples/basic/print.go
@@ -11,8 +11,7 @@ func init() {
 }
 
 type printCommand struct {
-	cli.Command
-	_ string `name:"print" short-description:"prints a message" long-description:"prints a very nice message"`
+	cli.Command `name:"print" short-description:"prints a message" long-description:"prints a very nice message"`
 
 	Message string `long:"message" env:"BASIC_MY_OPTION" default:"my-message" description:"my option does something"`
 }

--- a/examples/basic/print.go
+++ b/examples/basic/print.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	app.AddCommand(&printCommand{})
+}
+
+type printCommand struct {
+	cli.Command
+	_ string `name:"print" short-description:"prints a message" long-description:"prints a very nice message"`
+
+	Message string `long:"message" env:"BASIC_MY_OPTION" default:"my-message" description:"my option does something"`
+}
+
+func (c *printCommand) Execute(args []string) error {
+	fmt.Printf("Message: %s\n", c.Message)
+	return nil
+}

--- a/examples/basic/print_test.go
+++ b/examples/basic/print_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrint(t *testing.T) {
+	fixtures := []struct {
+		name   string
+		args   []string
+		stdout string
+		stderr string
+	}{{
+		name:   "default",
+		args:   []string{"test", "print"},
+		stdout: "Message: my-message\n",
+	}, {
+		name:   "one_message",
+		args:   []string{"test", "print", "--message", "hello"},
+		stdout: "Message: hello\n",
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			require := require.New(t)
+			var (
+				stdout, stderr string
+				err            error
+			)
+			stdout = capturer.CaptureStdout(func() {
+				stderr = capturer.CaptureStderr(func() {
+					err = app.Run(fixture.args)
+				})
+			})
+
+			require.NoError(err)
+			require.Equal(fixture.stderr, stderr)
+			require.Equal(fixture.stdout, stdout)
+		})
+	}
+}

--- a/examples/basic/sleep.go
+++ b/examples/basic/sleep.go
@@ -13,8 +13,7 @@ func init() {
 }
 
 type sleepCommand struct {
-	cli.Command
-	_ string `name:"sleep" short-description:"sleeps forever" long-description:"sleeps indefinitely until it receives SIGTERM or SIGINT"`
+	cli.Command `name:"sleep" short-description:"sleeps forever" long-description:"sleeps indefinitely until it receives SIGTERM or SIGINT"`
 
 	Positional struct {
 		Sleep time.Duration `positional-arg-name:"sleep" default:"1s" description:"sleep intervals"`

--- a/examples/basic/sleep.go
+++ b/examples/basic/sleep.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	app.AddCommand(&sleepCommand{})
+}
+
+type sleepCommand struct {
+	cli.Command
+	_ string `name:"sleep" short-description:"sleeps forever" long-description:"sleeps indefinitely until it receives SIGTERM or SIGINT"`
+
+	Positional struct {
+		Sleep time.Duration `positional-arg-name:"sleep" default:"1s" description:"sleep intervals"`
+	} `positional-args:"yes"`
+}
+
+func (c *sleepCommand) ExecuteContext(ctx context.Context, args []string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		fmt.Println("Sleeping...")
+		time.Sleep(c.Positional.Sleep)
+	}
+}

--- a/examples/basic/sleep_test.go
+++ b/examples/basic/sleep_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleep(t *testing.T) {
+	fixtures := []struct {
+		signal     os.Signal
+		signalName string
+	}{{
+		signalName: "SIGTERM",
+		signal:     syscall.SIGTERM,
+	}, {
+		signalName: "SIGINT",
+		signal:     syscall.SIGINT,
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.signalName, func(t *testing.T) {
+			require := require.New(t)
+			var (
+				stdout, stderr string
+				err            error
+			)
+
+			if fixture.signal != nil {
+				go func() {
+					time.Sleep(1 * time.Second)
+					pid := os.Getpid()
+					p, err := os.FindProcess(pid)
+					if err != nil {
+						panic(err)
+					}
+
+					p.Signal(fixture.signal)
+				}()
+			}
+
+			stdout = capturer.CaptureStdout(func() {
+				stderr = capturer.CaptureStderr(func() {
+					err = app.Run([]string{"test", "sleep"})
+				})
+			})
+
+			require.NoError(err)
+			require.True(strings.Contains(stdout, "Sleeping...\n"))
+			if fixture.signal != nil {
+				require.True(strings.Contains(stderr,
+					fmt.Sprintf("signal %s received", fixture.signalName)))
+			}
+		})
+	}
+}

--- a/examples/dynamic/main.go
+++ b/examples/dynamic/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+var (
+	version string
+	build   string
+)
+
+var app = cli.New("basic", version, build, "my basic command")
+
+func main() {
+	app.RunMain()
+}

--- a/examples/dynamic/main_test.go
+++ b/examples/dynamic/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+	require := require.New(t)
+	os.Args = []string{"test", "--help"}
+	var (
+		stdout, stderr string
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			main()
+		})
+	})
+
+	require.Empty(stderr)
+	require.True(strings.HasPrefix(stdout, "Usage:\n  basic"))
+}

--- a/examples/dynamic/print.go
+++ b/examples/dynamic/print.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	flags "github.com/jessevdk/go-flags"
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	app.AddCommand(&printCommand{}, addDefaultMessage)
+}
+
+const defaultMessage = "my-message"
+
+func addDefaultMessage(cmd *flags.Command) {
+	for _, opt := range cmd.Options() {
+		if opt.LongName == "message" {
+			opt.Default = []string{defaultMessage}
+		}
+	}
+}
+
+type printCommand struct {
+	cli.Command `name:"print" short-description:"prints a message" long-description:"prints a very nice message"`
+
+	Message string `long:"message" env:"BASIC_MY_OPTION" description:"my option does something"`
+}
+
+func (c *printCommand) Execute(args []string) error {
+	fmt.Printf("Message: %s\n", c.Message)
+	return nil
+}

--- a/examples/dynamic/print_test.go
+++ b/examples/dynamic/print_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrint(t *testing.T) {
+	fixtures := []struct {
+		name   string
+		args   []string
+		stdout string
+		stderr string
+	}{{
+		name:   "default",
+		args:   []string{"test", "print"},
+		stdout: "Message: my-message\n",
+	}, {
+		name:   "one_message",
+		args:   []string{"test", "print", "--message", "hello"},
+		stdout: "Message: hello\n",
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			require := require.New(t)
+			var (
+				stdout, stderr string
+				err            error
+			)
+			stdout = capturer.CaptureStdout(func() {
+				stderr = capturer.CaptureStderr(func() {
+					err = app.Run(fixture.args)
+				})
+			})
+
+			require.NoError(err)
+			require.Equal(fixture.stderr, stderr)
+			require.Equal(fixture.stdout, stdout)
+		})
+	}
+}

--- a/examples/subcommands/main.go
+++ b/examples/subcommands/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+var (
+	version string
+	build   string
+)
+
+var app = cli.New("basic", version, build, "my basic command")
+
+type subcommand struct {
+	cli.PlainCommand `name:"sub" short-description:"my subcommand" long-description:"my subcommand"`
+}
+
+var sub = app.AddCommand(&subcommand{})
+
+func main() {
+	app.RunMain()
+}

--- a/examples/subcommands/main_test.go
+++ b/examples/subcommands/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+	require := require.New(t)
+	os.Args = []string{"test", "--help"}
+	var (
+		stdout, stderr string
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			main()
+		})
+	})
+
+	require.Empty(stderr)
+	require.True(strings.HasPrefix(stdout, "Usage:\n  basic"))
+}
+
+func TestSubcommand(t *testing.T) {
+	require := require.New(t)
+	os.Args = []string{"test", "sub", "--help"}
+	var (
+		stdout, stderr string
+	)
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			main()
+		})
+	})
+
+	require.Empty(stderr)
+	require.True(strings.HasPrefix(stdout, "Usage:\n  basic"))
+}

--- a/examples/subcommands/print.go
+++ b/examples/subcommands/print.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	sub.AddCommand(&printCommand{})
+}
+
+type printCommand struct {
+	cli.Command `name:"print" short-description:"prints a message" long-description:"prints a very nice message"`
+
+	Message string `long:"message" env:"BASIC_MY_OPTION" default:"my-message" description:"my option does something"`
+}
+
+func (c *printCommand) Execute(args []string) error {
+	fmt.Printf("Message: %s\n", c.Message)
+	return nil
+}

--- a/examples/subcommands/print_test.go
+++ b/examples/subcommands/print_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrint(t *testing.T) {
+	fixtures := []struct {
+		name   string
+		args   []string
+		stdout string
+		stderr string
+	}{{
+		name:   "default",
+		args:   []string{"test", "sub", "print"},
+		stdout: "Message: my-message\n",
+	}, {
+		name:   "one_message",
+		args:   []string{"test", "sub", "print", "--message", "hello"},
+		stdout: "Message: hello\n",
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			require := require.New(t)
+			var (
+				stdout, stderr string
+				err            error
+			)
+			stdout = capturer.CaptureStdout(func() {
+				stderr = capturer.CaptureStderr(func() {
+					err = app.Run(fixture.args)
+				})
+			})
+
+			require.NoError(err)
+			require.Equal(fixture.stderr, stderr)
+			require.Equal(fixture.stdout, stdout)
+		})
+	}
+}

--- a/examples/subcommands/sleep.go
+++ b/examples/subcommands/sleep.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	sub.AddCommand(&sleepCommand{})
+}
+
+type sleepCommand struct {
+	cli.Command `name:"sleep" short-description:"sleeps forever" long-description:"sleeps indefinitely until it receives SIGTERM or SIGINT"`
+
+	Positional struct {
+		Sleep time.Duration `positional-arg-name:"sleep" default:"1s" description:"sleep intervals"`
+	} `positional-args:"yes"`
+}
+
+func (c *sleepCommand) ExecuteContext(ctx context.Context, args []string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		fmt.Println("Sleeping...")
+		time.Sleep(c.Positional.Sleep)
+	}
+}

--- a/examples/subcommands/sleep_test.go
+++ b/examples/subcommands/sleep_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleep(t *testing.T) {
+	fixtures := []struct {
+		signal     os.Signal
+		signalName string
+	}{{
+		signalName: "SIGTERM",
+		signal:     syscall.SIGTERM,
+	}, {
+		signalName: "SIGINT",
+		signal:     syscall.SIGINT,
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.signalName, func(t *testing.T) {
+			require := require.New(t)
+			var (
+				stdout, stderr string
+				err            error
+			)
+
+			if fixture.signal != nil {
+				go func() {
+					time.Sleep(1 * time.Second)
+					pid := os.Getpid()
+					p, err := os.FindProcess(pid)
+					if err != nil {
+						panic(err)
+					}
+
+					p.Signal(fixture.signal)
+				}()
+			}
+
+			stdout = capturer.CaptureStdout(func() {
+				stderr = capturer.CaptureStderr(func() {
+					err = app.Run([]string{"test", "sub", "sleep"})
+				})
+			})
+
+			require.NoError(err)
+			require.True(strings.Contains(stdout, "Sleeping...\n"))
+			if fixture.signal != nil {
+				require.True(strings.Contains(stderr,
+					fmt.Sprintf("signal %s received", fixture.signalName)))
+			}
+		})
+	}
+}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// LogOptions defines logging flags. It is meant to be embedded in a
+// command struct.
+type LogOptions struct {
+	LogLevel       string `long:"log-level" env:"LOG_LEVEL" default:"info" description:"Logging level (info, debug, warning or error)"`
+	LogFormat      string `long:"log-format" env:"LOG_FORMAT" description:"log format (text or json), defaults to text on a terminal and json otherwise"`
+	LogFields      string `long:"log-fields" env:"LOG_FIELDS" description:"default fields for the logger, specified in json"`
+	LogForceFormat bool   `long:"log-force-format" env:"LOG_FORCE_FORMAT" description:"ignore if it is running on a terminal or not"`
+}
+
+// Init initializes the default logger factory.
+func (c LogOptions) init(a *App) error {
+	log.DefaultFactory = &log.LoggerFactory{
+		Level:       c.LogLevel,
+		Format:      c.LogFormat,
+		Fields:      c.LogFields,
+		ForceFormat: c.LogForceFormat,
+	}
+
+	log.DefaultLogger = log.New(nil)
+	return nil
+}

--- a/pprof.go
+++ b/pprof.go
@@ -1,0 +1,287 @@
+package cli
+
+// This file is copied from standard net/http/pprof package.
+// Automatic registration of handler functions have been removed and all
+// symbols have been made private.
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pprof serves via its HTTP server runtime profiling data
+// in the format expected by the pprof visualization tool.
+//
+// The package is typically only imported for the side effect of
+// registering its HTTP handlers.
+// The handled paths all begin with /debug/pprof/.
+//
+// To use pprof, link this package into your program:
+//	import _ "net/http/pprof"
+//
+// If your application is not already running an http server, you
+// need to start one. Add "net/http" and "log" to your imports and
+// the following code to your main function:
+//
+// 	go func() {
+// 		log.Println(http.ListenAndServe("localhost:6060", nil))
+// 	}()
+//
+// Then use the pprof tool to look at the heap profile:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/heap
+//
+// Or to look at a 30-second CPU profile:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/profile
+//
+// Or to look at the goroutine blocking profile, after calling
+// runtime.SetBlockProfileRate in your program:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/block
+//
+// Or to collect a 5-second execution trace:
+//
+//	wget http://localhost:6060/debug/pprof/trace?seconds=5
+//
+// Or to look at the holders of contended mutexes, after calling
+// runtime.SetMutexProfileFraction in your program:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/mutex
+//
+// To view all available profiles, open http://localhost:6060/debug/pprof/
+// in your browser.
+//
+// For a study of the facility in action, visit
+//
+//	https://blog.golang.org/2011/06/profiling-go-programs.html
+//
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func registerPprof(http *http.ServeMux) {
+	http.HandleFunc("/debug/pprof/", pprofIndex)
+	http.HandleFunc("/debug/pprof/cmdline", pprofCmdline)
+	http.HandleFunc("/debug/pprof/profile", pprofProfile)
+	http.HandleFunc("/debug/pprof/symbol", pprofSymbol)
+	http.HandleFunc("/debug/pprof/trace", pprofTrace)
+}
+
+// Cmdline responds with the running program's
+// command line, with arguments separated by NUL bytes.
+// The package initialization registers it as /debug/pprof/cmdline.
+func pprofCmdline(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, strings.Join(os.Args, "\x00"))
+}
+
+func sleep(w http.ResponseWriter, d time.Duration) {
+	var clientGone <-chan bool
+	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone = cn.CloseNotify()
+	}
+	select {
+	case <-time.After(d):
+	case <-clientGone:
+	}
+}
+
+func durationExceedsWriteTimeout(r *http.Request, seconds float64) bool {
+	srv, ok := r.Context().Value(http.ServerContextKey).(*http.Server)
+	return ok && srv.WriteTimeout != 0 && seconds >= srv.WriteTimeout.Seconds()
+}
+
+func serveError(w http.ResponseWriter, status int, txt string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Go-Pprof", "1")
+	w.Header().Del("Content-Disposition")
+	w.WriteHeader(status)
+	fmt.Fprintln(w, txt)
+}
+
+// Profile responds with the pprof-formatted cpu profile.
+// The package initialization registers it as /debug/pprof/profile.
+func pprofProfile(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	sec, _ := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+	if sec == 0 {
+		sec = 30
+	}
+
+	if durationExceedsWriteTimeout(r, float64(sec)) {
+		serveError(w, http.StatusBadRequest, "profile duration exceeds server's WriteTimeout")
+		return
+	}
+
+	// Set Content Type assuming StartCPUProfile will work,
+	// because if it does it starts writing.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="profile"`)
+	if err := pprof.StartCPUProfile(w); err != nil {
+		// StartCPUProfile failed, so no writes yet.
+		serveError(w, http.StatusInternalServerError,
+			fmt.Sprintf("Could not enable CPU profiling: %s", err))
+		return
+	}
+	sleep(w, time.Duration(sec)*time.Second)
+	pprof.StopCPUProfile()
+}
+
+// Trace responds with the execution trace in binary form.
+// Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
+// The package initialization registers it as /debug/pprof/trace.
+func pprofTrace(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	sec, err := strconv.ParseFloat(r.FormValue("seconds"), 64)
+	if sec <= 0 || err != nil {
+		sec = 1
+	}
+
+	if durationExceedsWriteTimeout(r, sec) {
+		serveError(w, http.StatusBadRequest, "profile duration exceeds server's WriteTimeout")
+		return
+	}
+
+	// Set Content Type assuming trace.Start will work,
+	// because if it does it starts writing.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="trace"`)
+	if err := trace.Start(w); err != nil {
+		// trace.Start failed, so no writes yet.
+		serveError(w, http.StatusInternalServerError,
+			fmt.Sprintf("Could not enable tracing: %s", err))
+		return
+	}
+	sleep(w, time.Duration(sec*float64(time.Second)))
+	trace.Stop()
+}
+
+// Symbol looks up the program counters listed in the request,
+// responding with a table mapping program counters to function names.
+// The package initialization registers it as /debug/pprof/symbol.
+func pprofSymbol(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	// We have to read the whole POST body before
+	// writing any output. Buffer the output here.
+	var buf bytes.Buffer
+
+	// We don't know how many symbols we have, but we
+	// do have symbol information. Pprof only cares whether
+	// this number is 0 (no symbols available) or > 0.
+	fmt.Fprintf(&buf, "num_symbols: 1\n")
+
+	var b *bufio.Reader
+	if r.Method == "POST" {
+		b = bufio.NewReader(r.Body)
+	} else {
+		b = bufio.NewReader(strings.NewReader(r.URL.RawQuery))
+	}
+
+	for {
+		word, err := b.ReadSlice('+')
+		if err == nil {
+			word = word[0 : len(word)-1] // trim +
+		}
+		pc, _ := strconv.ParseUint(string(word), 0, 64)
+		if pc != 0 {
+			f := runtime.FuncForPC(uintptr(pc))
+			if f != nil {
+				fmt.Fprintf(&buf, "%#x %s\n", pc, f.Name())
+			}
+		}
+
+		// Wait until here to check for err; the last
+		// symbol will have an err because it doesn't end in +.
+		if err != nil {
+			if err != io.EOF {
+				fmt.Fprintf(&buf, "reading request: %v\n", err)
+			}
+			break
+		}
+	}
+
+	w.Write(buf.Bytes())
+}
+
+// Handler returns an HTTP handler that serves the named profile.
+func Handler(name string) http.Handler {
+	return handler(name)
+}
+
+type handler string
+
+func (name handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	p := pprof.Lookup(string(name))
+	if p == nil {
+		serveError(w, http.StatusNotFound, "Unknown profile")
+		return
+	}
+	gc, _ := strconv.Atoi(r.FormValue("gc"))
+	if name == "heap" && gc > 0 {
+		runtime.GC()
+	}
+	debug, _ := strconv.Atoi(r.FormValue("debug"))
+	if debug != 0 {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
+	}
+	p.WriteTo(w, debug)
+}
+
+// Index responds with the pprof-formatted profile named by the request.
+// For example, "/debug/pprof/heap" serves the "heap" profile.
+// Index responds to a request for "/debug/pprof/" with an HTML page
+// listing the available profiles.
+func pprofIndex(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/debug/pprof/") {
+		name := strings.TrimPrefix(r.URL.Path, "/debug/pprof/")
+		if name != "" {
+			handler(name).ServeHTTP(w, r)
+			return
+		}
+	}
+
+	profiles := pprof.Profiles()
+	if err := indexTmpl.Execute(w, profiles); err != nil {
+		log.Print(err)
+	}
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`<html>
+<head>
+<title>/debug/pprof/</title>
+</head>
+<body>
+/debug/pprof/<br>
+<br>
+profiles:<br>
+<table>
+{{range .}}
+<tr><td align=right>{{.Count}}<td><a href="{{.Name}}?debug=1">{{.Name}}</a>
+{{end}}
+</table>
+<br>
+<a href="goroutine?debug=2">full goroutine stack dump</a><br>
+</body>
+</html>
+`))

--- a/profiler.go
+++ b/profiler.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"net"
+	"net/http"
+	"runtime"
+
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// ProfilerOptions defines profiling flags. It is meant to be embedded in a
+// command struct.
+type ProfilerOptions struct {
+	ProfilerHTTP          bool   `long:"profiler-http" env:"PROFILER_HTTP" description:"start HTTP profiler endpoint"`
+	ProfilerBlockRate     int    `long:"profiler-block-rate" env:"PROFILER_BLOCK_RATE" default:"0" description:"runtime.SetBlockProfileRate parameter"`
+	ProfilerMutexFraction int    `long:"profiler-mutex-rate" env:"PROFILER_MUTEX_FRACTION" default:"0" description:"runtime.SetMutexProfileFraction parameter"`
+	ProfilerEndpoint      string `long:"profiler-endpoint" env:"PROFILER_endpoint" description:"address to bind HTTP pprof endpoint to" default:"0.0.0.0:6061"`
+}
+
+// Init initializes the profiler.
+func (c ProfilerOptions) init(a *App) error {
+	runtime.SetBlockProfileRate(c.ProfilerBlockRate)
+	runtime.SetMutexProfileFraction(c.ProfilerMutexFraction)
+
+	if c.ProfilerHTTP {
+		log.With(log.Fields{"address": c.ProfilerEndpoint}).
+			Debugf("starting http pprof endpoint")
+		registerPprof(a.DebugServeMux)
+		lis, err := net.Listen("tcp", c.ProfilerEndpoint)
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			err := http.Serve(lis, a.DebugServeMux)
+			if err != nil {
+				log.Errorf(err, "failed to serve http pprof endpoint")
+			}
+		}()
+	}
+
+	return nil
+}

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 type NopCommand struct {
-	_ string `name:"nop" short-description:"nop" long-description:"nop"`
-	Command
+	Command `name:"nop" short-description:"nop" long-description:"nop"`
 }
 
 func (c *NopCommand) Execute(args []string) error {

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type NopCommand struct {
+	_ string `name:"nop" short-description:"nop" long-description:"nop"`
+	Command
+}
+
+func (c *NopCommand) Execute(args []string) error {
+	return nil
+}
+
+func setupDefaultCommand(t *testing.T) *App {
+	app := New("test", "", "", "")
+	app.AddCommand(&NopCommand{})
+	return app
+}
+
+func TestProfilerOptions_Enable(t *testing.T) {
+	require := require.New(t)
+	app := setupDefaultCommand(t)
+	err := app.Run([]string{"test", "nop", "--profiler-http", "--profiler-block-rate", "10"})
+	require.NoError(err)
+}
+func TestProfilerOptions_Error(t *testing.T) {
+	require := require.New(t)
+	app := setupDefaultCommand(t)
+	err := app.Run([]string{"test", "nop", "--profiler-http", "--profiler-endpoint", "a.b.c.d:foo"})
+	require.Error(err)
+}

--- a/version.go
+++ b/version.go
@@ -7,10 +7,10 @@ import (
 // VersionCommand defines he default version command. Most if the time, it
 // should not be used directly, since it will be added by default to the App.
 type VersionCommand struct {
-	_       string `name:"version" short-description:"print version" long-description:"print version and exit"`
-	Name    string
-	Version string
-	Build   string
+	PlainCommand `name:"version" short-description:"print version" long-description:"print version and exit"`
+	Name         string
+	Version      string
+	Build        string
 }
 
 // Execute runs the version command.

--- a/version.go
+++ b/version.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+)
+
+// VersionCommand defines he default version command. Most if the time, it
+// should not be used directly, since it will be added by default to the App.
+type VersionCommand struct {
+	_       string `name:"version" short-description:"print version" long-description:"print version and exit"`
+	Name    string
+	Version string
+	Build   string
+}
+
+// Execute runs the version command.
+func (c VersionCommand) Execute(args []string) error {
+	fmt.Printf("%s version %s build %s\n", c.Name, c.Version, c.Build)
+	return nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCommand(t *testing.T) {
+	require := require.New(t)
+	app := New("test", "0.1.0", "abcde", "test app")
+	var (
+		stdout, stderr string
+		err            error
+	)
+
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "version"})
+		})
+	})
+
+	require.NoError(err)
+	require.Empty(stderr)
+	require.Equal("test version 0.1.0 build abcde\n", stdout)
+}


### PR DESCRIPTION
This is a thin wrapper around common libraries used in our CLI apps (`jessevdk/go-flags`, `src-d/go-log`, `pprof`) to reduce boilerplate code and help in being more homogeneous with respect how our CLI work and look like.

It provides:
- Struct tags to specify command names and descriptions (see below).
- Default version subcommand.
- Flags and environment variables to setup logging with src-d/go-log.
- Flags and environment variables to setup a http/pprof endpoint.
- Signal handling.

Most of what's included was modeled after borges CLI.

For further details, look at `doc.go`.