### PR TITLE
Add full process profile

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -131,3 +131,26 @@ type badCommander int
 func (badCommander) Execute(args []string) error {
 	return nil
 }
+
+func TestDefer(t *testing.T) {
+	require := require.New(t)
+
+	app := New("test", "0.1.0", "abc", "my test bin")
+	require.NotNil(app)
+
+	expected := []int{7, 6, 5, 4, 3, 2, 1, 0}
+	var result []int
+
+	for i := range expected {
+		num := i
+		app.Defer(func() {
+			result = append(result, num)
+		})
+	}
+
+	require.Nil(result)
+
+	err := app.Run([]string{"test", "version"})
+	require.NoError(err)
+	require.Equal(expected, result)
+}

--- a/profiler.go
+++ b/profiler.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"net"
 	"net/http"
+	"os"
 	"runtime"
+	"runtime/pprof"
 
 	"gopkg.in/src-d/go-log.v1"
 )
@@ -14,7 +16,8 @@ type ProfilerOptions struct {
 	ProfilerHTTP          bool   `long:"profiler-http" env:"PROFILER_HTTP" description:"start HTTP profiler endpoint"`
 	ProfilerBlockRate     int    `long:"profiler-block-rate" env:"PROFILER_BLOCK_RATE" default:"0" description:"runtime.SetBlockProfileRate parameter"`
 	ProfilerMutexFraction int    `long:"profiler-mutex-rate" env:"PROFILER_MUTEX_FRACTION" default:"0" description:"runtime.SetMutexProfileFraction parameter"`
-	ProfilerEndpoint      string `long:"profiler-endpoint" env:"PROFILER_endpoint" description:"address to bind HTTP pprof endpoint to" default:"0.0.0.0:6061"`
+	ProfilerEndpoint      string `long:"profiler-endpoint" env:"PROFILER_ENDPOINT" description:"address to bind HTTP pprof endpoint to" default:"0.0.0.0:6061"`
+	ProfilerCPU           string `long:"profiler-cpu" env:"PROFILER_CPU" description:"file where to write the whole execution CPU profile" default:""`
 }
 
 // Init initializes the profiler.
@@ -37,6 +40,21 @@ func (c ProfilerOptions) init(a *App) error {
 				log.Errorf(err, "failed to serve http pprof endpoint")
 			}
 		}()
+	}
+
+	if c.ProfilerCPU != "" {
+		log.With(log.Fields{"file": c.ProfilerCPU}).Debugf("starting CPU pprof")
+
+		cpu, err := os.Create(c.ProfilerCPU)
+		if err != nil {
+			return err
+		}
+
+		if err := pprof.StartCPUProfile(cpu); err != nil {
+			return err
+		}
+
+		a.Defer(func() { pprof.StopCPUProfile() })
 	}
 
 	return nil

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,9 +28,32 @@ func TestProfilerOptions_Enable(t *testing.T) {
 	err := app.Run([]string{"test", "nop", "--profiler-http", "--profiler-block-rate", "10"})
 	require.NoError(err)
 }
+
 func TestProfilerOptions_Error(t *testing.T) {
 	require := require.New(t)
 	app := setupDefaultCommand(t)
 	err := app.Run([]string{"test", "nop", "--profiler-http", "--profiler-endpoint", "a.b.c.d:foo"})
 	require.Error(err)
+}
+
+func TestProfilerCPU(t *testing.T) {
+	require := require.New(t)
+	app := setupDefaultCommand(t)
+
+	err := app.Run([]string{"test", "nop", "--profiler-cpu", "/directory/does/not/exist"})
+	require.Error(err)
+
+	tmp, err := ioutil.TempFile("", "cpu.prof")
+	if err != nil {
+		t.Fatalf("Could not create temporary file: %s", err.Error())
+	}
+
+	defer os.Remove(tmp.Name())
+
+	err = app.Run([]string{"test", "nop", "--profiler-cpu", tmp.Name()})
+	require.NoError(err)
+
+	stat, err := tmp.Stat()
+	require.NoError(err)
+	require.NotZero(stat.Size())
 }


### PR DESCRIPTION
Add `--profiler-cpu` option to save full process CPU profile. `http` profile only gets 30s of execution since it is called and sometimes is not enough. To be able to stop profiler after execution of command the function `Defer` was added to `App` so functions can be executed after commands.

Memory profile was not added as it not makes sense. It saves the snapshot of memory at the moment it is called. If this is done at the start or end of the execution doesn't give any interesting data. For memory it's better to use `--profiler-http`.