### PR TITLE
Use 'choice' in LogOptions

### DIFF
--- a/log.go
+++ b/log.go
@@ -7,8 +7,8 @@ import (
 // LogOptions defines logging flags. It is meant to be embedded in a
 // command struct.
 type LogOptions struct {
-	LogLevel       string `long:"log-level" env:"LOG_LEVEL" default:"info" description:"Logging level (info, debug, warning or error)"`
-	LogFormat      string `long:"log-format" env:"LOG_FORMAT" description:"log format (text or json), defaults to text on a terminal and json otherwise"`
+	LogLevel       string `long:"log-level" env:"LOG_LEVEL" choice:"info" choice:"debug" choice:"warning" choice:"error" default:"info" description:"Logging level"`
+	LogFormat      string `long:"log-format" env:"LOG_FORMAT" choice:"text" choice:"json" description:"log format, defaults to text on a terminal and json otherwise"`
 	LogFields      string `long:"log-fields" env:"LOG_FIELDS" description:"default fields for the logger, specified in json"`
 	LogForceFormat bool   `long:"log-force-format" env:"LOG_FORCE_FORMAT" description:"ignore if it is running on a terminal or not"`
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type LogCommand struct {
+	Command `name:"nop" short-description:"nop" long-description:"nop"`
+}
+
+func (c *LogCommand) Execute(args []string) error {
+	return nil
+}
+
+func setupLogCommand(t *testing.T) *App {
+	app := New("test", "", "", "")
+	app.AddCommand(&LogCommand{})
+	return app
+}
+
+func TestLogLevel(t *testing.T) {
+	fixtures := []struct {
+		level string
+		err   bool
+	}{{
+		level: "info",
+		err:   false,
+	}, {
+		level: "debug",
+		err:   false,
+	}, {
+		level: "warning",
+		err:   false,
+	}, {
+		level: "error",
+		err:   false,
+	}, {
+		level: "other",
+		err:   true,
+	}}
+
+	app := setupLogCommand(t)
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.level, func(t *testing.T) {
+			require := require.New(t)
+
+			err := app.Run([]string{"test", "nop",
+				fmt.Sprintf("--log-level=%s", fixture.level)})
+
+			if fixture.err {
+				require.NotNil(err)
+				require.Contains(err.Error(), "Invalid value")
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}
+
+func TestLogFormat(t *testing.T) {
+	fixtures := []struct {
+		format string
+		err    bool
+	}{{
+		format: "text",
+		err:    false,
+	}, {
+		format: "json",
+		err:    false,
+	}, {
+		format: "txt",
+		err:    true,
+	}}
+
+	app := setupLogCommand(t)
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.format, func(t *testing.T) {
+			require := require.New(t)
+
+			err := app.Run([]string{"test", "nop",
+				fmt.Sprintf("--log-format=%s", fixture.format)})
+
+			if fixture.err {
+				require.NotNil(err)
+				require.Contains(err.Error(), "Invalid value")
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Using 'choice' we get nicer help and errors.

Before:
```
    Log Options:
          --log-level=           Logging level (info, debug, warning or error) (default: info) [$LOG_LEVEL]
          --log-format=          log format (text or json), defaults to text on a terminal and json otherwise [$LOG_FORMAT]
          --log-fields=          default fields for the logger, specified in json [$LOG_FIELDS]
          --log-force-format     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
```
```
panic: invalid level nope, valid levels are: [error panic info debug warning]

goroutine 1 [running]:
gopkg.in/src-d/go-cli.v0/vendor/gopkg.in/src-d/go-log%2ev1.New(0x0, 0xc42014a0c0, 0x745b84)
	/home/cmartin/go/src/gopkg.in/src-d/go-cli.v0/vendor/gopkg.in/src-d/go-log.v1/default.go:39 +0x19d
gopkg.in/src-d/go-cli%2ev0.LogOptions.Init(0x7fffaee370b3, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42014e060, 0xa57280, 0x7f9e05713078)
....
```

After:
```
    Log Options:
          --log-level=[info|debug|warning|error] Logging level (default: info) [$LOG_LEVEL]
          --log-format=[text|json]               log format, defaults to text on a terminal and json otherwise [$LOG_FORMAT]
          --log-fields=                          default fields for the logger, specified in json [$LOG_FIELDS]
          --log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
```
```
Invalid value `nope' for option `--log-level'. Allowed values are: info, debug, warning or error
```