### PR TITLE
add custom signal handling

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -94,9 +94,7 @@ func (a *App) commandHandler(cmd flags.Commander, args []string) error {
 	}
 
 	if v, ok := cmd.(ContextCommander); ok {
-		ctx, cancel := setupContext()
-		defer cancel()
-		return v.ExecuteContext(ctx, args)
+		return executeContextCommander(v, args)
 	}
 
 	return cmd.Execute(args)

--- a/context.go
+++ b/context.go
@@ -9,13 +9,46 @@ import (
 	"gopkg.in/src-d/go-log.v1"
 )
 
-// ContextCommander is a cancellable commander.
+// ContextCommander is a cancellable commander. By default, receiving SIGTERM or
+// SIGINT will cancel the context. For overriding the default behaviour, see the
+// SignalHandler interface.
 type ContextCommander interface {
 	// ExecuteContext executes the command with a context.
 	ExecuteContext(context.Context, []string) error
 }
 
-func setupContext() (context.Context, context.CancelFunc) {
+// SignalHandler can be implemented by a ContextCommander to override default
+// signal handling (which is logging the signal and cancelling the context).
+// If this interface is implemented, HandleSignal will be called when SIGTERM or
+// SIGINT is received, and no other signal handling will be performed.
+type SignalHandler interface {
+	// HandleSignal takes the received signal (SIGTERM or SIGINT) and the
+	// CancelFunc of the context.Context passed to ExecuteContext.
+	HandleSignal(os.Signal, context.CancelFunc)
+}
+
+func executeContextCommander(cmd ContextCommander, args []string) error {
+	handler := defaultSignalHandler
+	if v, ok := cmd.(SignalHandler); ok {
+		handler = v.HandleSignal
+	}
+
+	ctx := setupContext(handler)
+	return cmd.ExecuteContext(ctx, args)
+}
+
+func defaultSignalHandler(signal os.Signal, cancel context.CancelFunc) {
+	switch signal {
+	case syscall.SIGTERM:
+		log.Infof("signal SIGTERM received, stopping...")
+	case os.Interrupt:
+		log.Infof("signal SIGINT received, stopping...")
+	}
+
+	cancel()
+}
+
+func setupContext(handler func(os.Signal, context.CancelFunc)) context.Context {
 	var (
 		sigterm = make(chan os.Signal)
 		sigint  = make(chan os.Signal)
@@ -24,13 +57,10 @@ func setupContext() (context.Context, context.CancelFunc) {
 
 	go func() {
 		select {
-		case <-sigterm:
-			log.Infof("signal SIGTERM received, stopping...")
-			cancel()
-		case <-sigint:
-			log.Infof("signal SIGINT received, stopping...")
-			cancel()
-		case <-ctx.Done():
+		case sig := <-sigterm:
+			handler(sig, cancel)
+		case sig := <-sigint:
+			handler(sig, cancel)
 		}
 
 		signal.Stop(sigterm)
@@ -40,5 +70,5 @@ func setupContext() (context.Context, context.CancelFunc) {
 	signal.Notify(sigterm, syscall.SIGTERM)
 	signal.Notify(sigint, os.Interrupt)
 
-	return ctx, cancel
+	return ctx
 }

--- a/examples/signals/main.go
+++ b/examples/signals/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+var (
+	version string
+	build   string
+)
+
+var app = cli.New("basic", version, build, "my basic command")
+
+func main() {
+	app.RunMain()
+}

--- a/examples/signals/main_test.go
+++ b/examples/signals/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testBin string
+
+func init() {
+	bin := "test"
+	if runtime.GOOS == "windows" {
+		bin = "test.exe"
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	testBin = filepath.Join(dir, bin)
+
+	cmd := exec.Command("go", "build", "-o", testBin, ".")
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+
+}
+
+func TestMain(t *testing.T) {
+	require := require.New(t)
+
+	cmd := exec.Command(testBin, "--help")
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	require.NoError(err)
+
+	require.Empty(stderr.String())
+	require.True(strings.HasPrefix(stdout.String(), "Usage:\n  basic"))
+}

--- a/examples/signals/sleep.go
+++ b/examples/signals/sleep.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+func init() {
+	app.AddCommand(&sleepCommand{})
+}
+
+type sleepCommand struct {
+	cli.Command `name:"sleep" short-description:"sleeps forever" long-description:"sleeps indefinitely until it receives SIGTERM or SIGINT"`
+
+	Sleep time.Duration `long:"duration" default:"1s" description:"sleep intervals"`
+}
+
+func (c *sleepCommand) ExecuteContext(ctx context.Context, args []string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		fmt.Println("Sleeping...")
+		time.Sleep(c.Sleep)
+	}
+}
+
+func (c *sleepCommand) HandleSignal(sig os.Signal, cancel context.CancelFunc) {
+	fmt.Fprintln(os.Stderr, "Custom signal handling")
+	cancel()
+}

--- a/examples/signals/sleep_test.go
+++ b/examples/signals/sleep_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleep(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not supported on Windows")
+	}
+
+	fixtures := []struct {
+		signal     os.Signal
+		signalName string
+	}{{
+		signalName: "SIGTERM",
+		signal:     syscall.SIGTERM,
+	}, {
+		signalName: "SIGINT",
+		signal:     syscall.SIGINT,
+	}}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.signalName, func(t *testing.T) {
+			require := require.New(t)
+
+			cmd := exec.Command(testBin, "sleep")
+
+			stdout := bytes.NewBuffer(nil)
+			stderr := bytes.NewBuffer(nil)
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+
+			ready := make(chan struct{})
+			go func() {
+				err := cmd.Run()
+				require.NoError(err)
+				ready <- struct{}{}
+			}()
+
+			if fixture.signal != nil {
+				time.Sleep(1 * time.Second)
+				p, oerr := os.FindProcess(cmd.Process.Pid)
+				require.NoError(oerr)
+				require.NoError(p.Signal(fixture.signal))
+			}
+			<-ready
+
+			require.True(strings.Contains(stdout.String(), "Sleeping...\n"))
+			if fixture.signal != nil {
+				require.True(strings.Contains(stderr.String(),
+					"Custom signal handling"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- added SignalHandler interface to override signal handling.
- add examples/signals example.
- remove context cancel after command execution finished.

Fixes #11 