### PR TITLE
Add bash completion sub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A thin wrapper around common libraries used in our CLI apps (`jessevdk/go-flags`
 It provides:
 - Struct tags to specify command names and descriptions (see below).
 - Default version subcommand.
+- Default completion subcommand for bash completion.
 - Flags and environment variables to setup logging with src-d/go-log.
 - Flags and environment variables to setup a http/pprof endpoint.
 - Signal handling.

--- a/cli.go
+++ b/cli.go
@@ -33,6 +33,10 @@ func New(name, version, build, description string) *App {
 		Build:   build,
 	})
 
+	app.AddCommand(&CompletionCommand{
+		Name: name,
+	}, InitCompletionCommand(name))
+
 	return app
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -28,7 +28,7 @@ func TestHelp(t *testing.T) {
 	require.Empty(stderr)
 	if runtime.GOOS == "windows" {
 		require.Equal(`Usage:
-  test [OPTIONS] <version>
+  test [OPTIONS] <completion | version>
 
 my test bin
 
@@ -37,12 +37,13 @@ Help Options:
   /h, /help   Show this help message
 
 Available commands:
-  version  print version
+  completion  print bash completion script
+  version     print version
 
 `, stdout)
 	} else {
 		require.Equal(`Usage:
-  test [OPTIONS] <version>
+  test [OPTIONS] <completion | version>
 
 my test bin
 
@@ -50,7 +51,8 @@ Help Options:
   -h, --help  Show this help message
 
 Available commands:
-  version  print version
+  completion  print bash completion script
+  version     print version
 
 `, stdout)
 	}
@@ -77,7 +79,7 @@ func TestHelpError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		require.Equal(`unknown flag `+"`"+`bad-option'
 Usage:
-  test [OPTIONS] <version>
+  test [OPTIONS] <completion | version>
 
 my test bin
 
@@ -86,12 +88,13 @@ Help Options:
   /h, /help   Show this help message
 
 Available commands:
-  version  print version
+  completion  print bash completion script
+  version     print version
 `, stderr)
 	} else {
 		require.Equal(`unknown flag `+"`"+`bad-option'
 Usage:
-  test [OPTIONS] <version>
+  test [OPTIONS] <completion | version>
 
 my test bin
 
@@ -99,7 +102,8 @@ Help Options:
   -h, --help  Show this help message
 
 Available commands:
-  version  print version
+  completion  print bash completion script
+  version     print version
 `, stderr)
 	}
 }

--- a/completion.go
+++ b/completion.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"text/template"
+
+	"github.com/jessevdk/go-flags"
+)
+
+// CompletionCommand defines the default completion command. Most of the time, it
+// should not be used directly, since it will be added by default to the App.
+type CompletionCommand struct {
+	PlainCommand `name:"completion" short-description:"print bash completion script"`
+	Name         string
+}
+
+// InitCompletionCommand returns an additional AddCommand function that fills
+// the CompletionCommand long description
+func InitCompletionCommand(appname string) func(*flags.Command) {
+	return func(c *flags.Command) {
+		t := template.Must(template.New("desc").Parse(
+			`Print a bash completion script for {{.Name}}.
+
+You can place it on /etc/bash_completion.d/{{.Name}}, or add it to your .bashrc:
+    echo "source <({{.Name}} completion)" >> ~/.bashrc
+`))
+
+		var tpl bytes.Buffer
+		t.Execute(&tpl, struct{ Name string }{appname})
+		c.LongDescription = tpl.String()
+	}
+}
+
+// Execute runs the install command.
+func (c CompletionCommand) Execute(args []string) error {
+	t := template.Must(template.New("completion").Parse(
+		`# Save this file to /etc/bash_completion.d/{{.Name}}
+#
+# or add the following line to your .bashrc file: 
+#   echo "source <({{.Name}} completion)" >> ~/.bashrc
+
+_completion-{{.Name}}() {
+    # All arguments except the first one
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+
+    # Only split on newlines
+    local IFS=$'\n'
+
+    # Call completion (note that the first element of COMP_WORDS is
+    # the executable itself)
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+    return 0
+}
+
+complete -F _completion-{{.Name}} {{.Name}}
+`))
+
+	err := t.Execute(os.Stdout, struct{ Name string }{c.Name})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionCommand(t *testing.T) {
+	require := require.New(t)
+	app := New("test", "0.1.0", "abcde", "test app")
+	var (
+		stdout, stderr string
+		err            error
+	)
+
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "completion"})
+		})
+	})
+
+	require.NoError(err)
+	require.Empty(stderr)
+	require.Equal(
+		`# Save this file to /etc/bash_completion.d/test
+#
+# or add the following line to your .bashrc file: 
+#   echo "source <(test completion)" >> ~/.bashrc
+
+_completion-test() {
+    # All arguments except the first one
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+
+    # Only split on newlines
+    local IFS=$'\n'
+
+    # Call completion (note that the first element of COMP_WORDS is
+    # the executable itself)
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+    return 0
+}
+
+complete -F _completion-test test
+`, stdout)
+}
+
+func TestCompletionHelpCommand(t *testing.T) {
+	require := require.New(t)
+	app := New("test", "0.1.0", "abcde", "test app")
+	var (
+		stdout, stderr string
+		err            error
+	)
+
+	stdout = capturer.CaptureStdout(func() {
+		stderr = capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "completion", "--help"})
+		})
+	})
+
+	require.NoError(err)
+	require.Empty(stderr)
+	if runtime.GOOS == "windows" {
+		require.Equal(
+			`Usage:
+  test [OPTIONS] completion
+
+Print a bash completion script for test.
+
+You can place it on /etc/bash_completion.d/test, or add it to your .bashrc:
+echo "source <(test completion)" >> ~/.bashrc
+
+
+Help Options:
+  /?              Show this help message
+  /h, /help       Show this help message
+
+`, stdout)
+
+	} else {
+		require.Equal(
+			`Usage:
+  test [OPTIONS] completion
+
+Print a bash completion script for test.
+
+You can place it on /etc/bash_completion.d/test, or add it to your .bashrc:
+echo "source <(test completion)" >> ~/.bashrc
+
+
+Help Options:
+  -h, --help      Show this help message
+
+`, stdout)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -8,6 +8,7 @@ It provides:
 
   - Struct tags to specify command names and descriptions (see below).
   - Default version subcommand.
+  - Default completion subcommand for bash completion.
   - Flags and environment variables to setup logging with src-d/go-log.
   - Flags and environment variables to setup a http/pprof endpoint.
   - Signal handling.


### PR DESCRIPTION
This PR adds a new `completion` default sub command. It outputs a script that provides bash completion.

It's based on the [jessevdk/go-flags docs](https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion) and the [kubectl docs](https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion).

For lookout it looks like this:
```
$ lookoutd completion -h
Usage:
  lookoutd [OPTIONS] completion

Print a bash completion script for lookoutd.

You can place it on /etc/bash_completion.d/lookoutd, or add it to your .bashrc:
echo "source <(lookoutd completion)" >> ~/.bashrc


Help Options:
  -h, --help      Show this help message
```
```
$ lookoutd completion 
# Save this file to /etc/bash_completion.d/lookoutd
#
# or add the following line to your .bashrc file: 
#   echo "source <(lookoutd completion)" >> ~/.bashrc

_completion-lookoutd() {
    # All arguments except the first one
    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")

    # Only split on newlines
    local IFS=$'\n'

    # Call completion (note that the first element of COMP_WORDS is
    # the executable itself)
    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
    return 0
}

complete -F _completion-lookoutd lookoutd
```
![completion](https://user-images.githubusercontent.com/1469173/53746694-ae7f2f80-3e99-11e9-8aea-5783dcd0e2b3.gif)
