### PR TITLE
Add new constructor without version sub command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -23,8 +23,21 @@ type App struct {
 	deferFuncs []DeferFunc
 }
 
-// New creates a new App, including default values.
+// New creates a new App, including default values and sub commands.
 func New(name, version, build, description string) *App {
+	app := NewNoDefaults(name, description)
+
+	app.AddCommand(&VersionCommand{
+		Name:    name,
+		Version: version,
+		Build:   build,
+	})
+
+	return app
+}
+
+// NewNoDefaults creates a new App, without any of the default sub commands.
+func NewNoDefaults(name, description string) *App {
 	parser := flags.NewNamedParser(name, flags.Default)
 	parser.LongDescription = description
 	app := &App{
@@ -33,12 +46,6 @@ func New(name, version, build, description string) *App {
 	}
 
 	app.Parser.CommandHandler = app.commandHandler
-
-	app.AddCommand(&VersionCommand{
-		Name:    name,
-		Version: version,
-		Build:   build,
-	})
 
 	return app
 }


### PR DESCRIPTION
We are migrating Engine from cobra to this lib.
But Engine already contains a `version` sub command that provides info about the command, the srcd-cli container, and the docker host.

This PR adds a new constructor to be able to create an App without any of the default sub commands (only `version` for now).

See: https://github.com/src-d/engine/pull/425