### PR TITLE
Explain better how to install completion script

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -22,7 +22,7 @@ func InitCompletionCommand(appname string) func(*flags.Command) {
 		t := template.Must(template.New("desc").Parse(
 			`Print a bash completion script for {{.Name}}.
 
-You can place it on /etc/bash_completion.d/{{.Name}}, or add it to your .bashrc:
+You can place it on /etc/bash_completion.d/{{.Name}}, or add it to your .bashrc running:
     echo "source <({{.Name}} completion)" >> ~/.bashrc
 `))
 
@@ -37,7 +37,9 @@ func (c CompletionCommand) Execute(args []string) error {
 	t := template.Must(template.New("completion").Parse(
 		`# Save this file to /etc/bash_completion.d/{{.Name}}
 #
-# or add the following line to your .bashrc file: 
+# or add the following line to your .bashrc file:
+#   source <({{.Name}} completion)
+# running:
 #   echo "source <({{.Name}} completion)" >> ~/.bashrc
 
 _completion-{{.Name}}() {

--- a/completion_test.go
+++ b/completion_test.go
@@ -31,7 +31,9 @@ func TestCompletionCommand(t *testing.T) {
 	require.Equal(
 		`# Save this file to /etc/bash_completion.d/test
 #
-# or add the following line to your .bashrc file: 
+# or add the following line to your .bashrc file:
+#   source <(test completion)
+# running:
 #   echo "source <(test completion)" >> ~/.bashrc
 
 _completion-test() {
@@ -77,7 +79,8 @@ func TestCompletionHelpCommand(t *testing.T) {
 
 Print a bash completion script for test.
 
-You can place it on /etc/bash_completion.d/test, or add it to your .bashrc:
+You can place it on /etc/bash_completion.d/test, or add it to your .bashrc
+running:
 echo "source <(test completion)" >> ~/.bashrc
 
 


### PR DESCRIPTION
Current hint suggests adding a line into `.bashrc` that adds a line into `.bashrc`, what is incorrect.
