### PR TITLE
Remove completion command on Windows

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"runtime"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -33,9 +34,11 @@ func New(name, version, build, description string) *App {
 		Build:   build,
 	})
 
-	app.AddCommand(&CompletionCommand{
-		Name: name,
-	}, InitCompletionCommand(name))
+	if runtime.GOOS != "windows" {
+		app.AddCommand(&CompletionCommand{
+			Name: name,
+		}, InitCompletionCommand(name))
+	}
 
 	return app
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -28,7 +28,7 @@ func TestHelp(t *testing.T) {
 	require.Empty(stderr)
 	if runtime.GOOS == "windows" {
 		require.Equal(`Usage:
-  test [OPTIONS] <completion | version>
+  test [OPTIONS] <version>
 
 my test bin
 
@@ -37,8 +37,7 @@ Help Options:
   /h, /help   Show this help message
 
 Available commands:
-  completion  print bash completion script
-  version     print version
+  version  print version
 
 `, stdout)
 	} else {
@@ -79,7 +78,7 @@ func TestHelpError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		require.Equal(`unknown flag `+"`"+`bad-option'
 Usage:
-  test [OPTIONS] <completion | version>
+  test [OPTIONS] <version>
 
 my test bin
 
@@ -88,8 +87,7 @@ Help Options:
   /h, /help   Show this help message
 
 Available commands:
-  completion  print bash completion script
-  version     print version
+  version  print version
 `, stderr)
 	} else {
 		require.Equal(`unknown flag `+"`"+`bad-option'

--- a/completion_test.go
+++ b/completion_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestCompletionCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no completion command on windows")
+	}
+
 	require := require.New(t)
 	app := New("test", "0.1.0", "abcde", "test app")
 	var (
@@ -48,6 +52,10 @@ complete -F _completion-test test
 }
 
 func TestCompletionHelpCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no completion command on windows")
+	}
+
 	require := require.New(t)
 	app := New("test", "0.1.0", "abcde", "test app")
 	var (
@@ -63,25 +71,7 @@ func TestCompletionHelpCommand(t *testing.T) {
 
 	require.NoError(err)
 	require.Empty(stderr)
-	if runtime.GOOS == "windows" {
-		require.Equal(
-			`Usage:
-  test [OPTIONS] completion
-
-Print a bash completion script for test.
-
-You can place it on /etc/bash_completion.d/test, or add it to your .bashrc:
-echo "source <(test completion)" >> ~/.bashrc
-
-
-Help Options:
-  /?              Show this help message
-  /h, /help       Show this help message
-
-`, stdout)
-
-	} else {
-		require.Equal(
+	require.Equal(
 			`Usage:
   test [OPTIONS] completion
 
@@ -95,5 +85,4 @@ Help Options:
   -h, --help      Show this help message
 
 `, stdout)
-	}
 }


### PR DESCRIPTION
Fix: https://github.com/src-d/sourced-ce/issues/169

The completion command is specific to bash but we use go-cli on windows
with powershell as well.

//cc @smola @carlosms for review