### PR TITLE
Remove completion command on Windows

### DIFF
--- a/addcommand.go
+++ b/addcommand.go
@@ -7,6 +7,12 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+// Validable can be used to confirm if a subcommand can be added
+type Validable interface {
+	// IsValid returns true if the subcommand can be added
+	IsValid() bool
+}
+
 // AddCommand adds a new command to the application. The command must have a
 // special field defining name, short-description and long-description (see
 // package documentation). It panics if the command is not valid.
@@ -15,13 +21,17 @@ import (
 // Additional functions can be passed to manipulate the resulting *flags.Command
 // after its initialization.
 func (a *App) AddCommand(cmd interface{}, cfs ...func(*flags.Command)) CommandAdder {
+	if v, ok := cmd.(Validable); ok && !v.IsValid() {
+		return a
+	}
+
 	return commandAdder{a.Parser}.AddCommand(cmd, cfs...)
 }
 
 // CommandAdder can be used to add subcommands.
 type CommandAdder interface {
 	// AddCommand adds the given commands as subcommands of the
-	// cuurent one.
+	// curent one.
 	AddCommand(interface{}, ...func(*flags.Command)) CommandAdder
 }
 

--- a/cli.go
+++ b/cli.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"runtime"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -34,11 +33,9 @@ func New(name, version, build, description string) *App {
 		Build:   build,
 	})
 
-	if runtime.GOOS != "windows" {
-		app.AddCommand(&CompletionCommand{
-			Name: name,
-		}, InitCompletionCommand(name))
-	}
+	app.AddCommand(&CompletionCommand{
+		Name: name,
+	}, InitCompletionCommand(name))
 
 	return app
 }

--- a/completion.go
+++ b/completion.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"os"
+	"runtime"
 	"text/template"
 
 	"github.com/jessevdk/go-flags"
@@ -13,6 +14,12 @@ import (
 type CompletionCommand struct {
 	PlainCommand `name:"completion" short-description:"print bash completion script"`
 	Name         string
+}
+
+// IsValid CompletionCommand is specific to bash, so not available in windows (using powershell)
+// see https://github.com/src-d/go-cli/pull/20#pullrequestreview-273691437
+func (c *CompletionCommand) IsValid() bool {
+	return runtime.GOOS != "windows"
 }
 
 // InitCompletionCommand returns an additional AddCommand function that fills

--- a/completion_test.go
+++ b/completion_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestCompletionCommand(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no completion command on windows")
-	}
 
 	require := require.New(t)
 	app := New("test", "0.1.0", "abcde", "test app")
@@ -25,6 +22,11 @@ func TestCompletionCommand(t *testing.T) {
 			err = app.Run([]string{"test", "completion"})
 		})
 	})
+
+	if runtime.GOOS == "windows" {
+		require.Error(err, "completion subcommand should not be available in Windows")
+		return
+	}
 
 	require.NoError(err)
 	require.Empty(stderr)
@@ -52,10 +54,6 @@ complete -F _completion-test test
 }
 
 func TestCompletionHelpCommand(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no completion command on windows")
-	}
-
 	require := require.New(t)
 	app := New("test", "0.1.0", "abcde", "test app")
 	var (
@@ -69,10 +67,15 @@ func TestCompletionHelpCommand(t *testing.T) {
 		})
 	})
 
+	if runtime.GOOS == "windows" {
+		require.Error(err, "completion subcommand should not be available in Windows")
+		return
+	}
+
 	require.NoError(err)
 	require.Empty(stderr)
 	require.Equal(
-			`Usage:
+		`Usage:
   test [OPTIONS] completion
 
 Print a bash completion script for test.
@@ -85,4 +88,31 @@ Help Options:
   -h, --help      Show this help message
 
 `, stdout)
+}
+
+func TestCompletionCommandAdd(t *testing.T) {
+	require := require.New(t)
+	app := NewNoDefaults("test", "test app")
+	app.AddCommand(&CompletionCommand{
+		Name: "test",
+	}, InitCompletionCommand("test"))
+	app.AddCommand(&VersionCommand{
+		Name:    "test",
+		Version: "0.1.0",
+		Build:   "abcde",
+	})
+
+	var err error
+
+	capturer.CaptureStdout(func() {
+		capturer.CaptureStderr(func() {
+			err = app.Run([]string{"test", "completion"})
+		})
+	})
+
+	if runtime.GOOS == "windows" {
+		require.Error(err, "completion subcommand should not be available in Windows")
+	} else {
+		require.NoError(err, "completion subcommand should be available in Linux")
+	}
 }


### PR DESCRIPTION
Fix: https://github.com/src-d/sourced-ce/issues/169

The completion command is specific to bash but we use go-cli on windows
with PowerShell as well.

The previous solution from https://github.com/src-d/go-cli/pull/20 is not enough because `CompletionCommand` can be manually added as done in [sourced-ce/cmd/sourced/cmd/root.go#L30](https://github.com/src-d/sourced-ce/blob/master/cmd/sourced/cmd/root.go#L30)

With this approach, subcommands can implement the new `Validable` interface which will let `go-cli` know if the subcommand can be added or not.